### PR TITLE
add trait `Codec` for H64 

### DIFF
--- a/ethereum-types/Cargo.toml
+++ b/ethereum-types/Cargo.toml
@@ -14,11 +14,12 @@ uint-crate = { path = "../uint", package = "uint", version = "0.8", default-feat
 primitive-types = { path = "../primitive-types", version = "0.6", features = ["rlp", "byteorder", "rustc-hex"], default-features = false }
 impl-serde = { path = "../primitive-types/impls/serde", version = "0.2", default-features = false, optional = true }
 impl-rlp = { path = "../primitive-types/impls/rlp", version = "0.2", default-features = false }
+impl-codec = { path = "../primitive-types/impls/codec", default-features = false }
 
 [dev-dependencies]
 serde_json = "1.0.41"
 
 [features]
 default = ["std", "serialize"]
-std = ["uint-crate/std", "fixed-hash/std", "ethbloom/std", "primitive-types/std"]
+std = ["uint-crate/std", "fixed-hash/std", "ethbloom/std", "primitive-types/std", "impl-codec/std"]
 serialize = ["std", "impl-serde", "primitive-types/serde", "ethbloom/serialize"]

--- a/ethereum-types/src/hash.rs
+++ b/ethereum-types/src/hash.rs
@@ -3,6 +3,7 @@ use fixed_hash::*;
 use impl_rlp::impl_fixed_hash_rlp;
 #[cfg(feature = "serialize")]
 use impl_serde::impl_fixed_hash_serde;
+use impl_codec::impl_fixe d_hash_codec;
 
 pub trait BigEndianHash {
 	type Uint;
@@ -15,16 +16,19 @@ construct_fixed_hash! { pub struct H32(4); }
 impl_fixed_hash_rlp!(H32, 4);
 #[cfg(feature = "serialize")]
 impl_fixed_hash_serde!(H32, 4);
+impl_fixed_hash_codec!(H32, 4);
 
 construct_fixed_hash! { pub struct H64(8); }
 impl_fixed_hash_rlp!(H64, 8);
 #[cfg(feature = "serialize")]
 impl_fixed_hash_serde!(H64, 8);
+impl_fixed_hash_codec!(H64, 8);
 
 construct_fixed_hash! { pub struct H128(16); }
 impl_fixed_hash_rlp!(H128, 16);
 #[cfg(feature = "serialize")]
 impl_fixed_hash_serde!(H128, 16);
+impl_fixed_hash_codec!(H128, 16);
 
 pub use primitive_types::H160;
 pub use primitive_types::H256;

--- a/ethereum-types/src/hash.rs
+++ b/ethereum-types/src/hash.rs
@@ -3,7 +3,7 @@ use fixed_hash::*;
 use impl_rlp::impl_fixed_hash_rlp;
 #[cfg(feature = "serialize")]
 use impl_serde::impl_fixed_hash_serde;
-use impl_codec::impl_fixe d_hash_codec;
+use impl_codec::impl_fixed_hash_codec;
 
 pub trait BigEndianHash {
 	type Uint;


### PR DESCRIPTION
to avoid the `different version of dependencies` error for those that depend on this repo.